### PR TITLE
docs: update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 </h3>
 
 <p align="center">
-	<a href="https://github.com/aszecsei/hexchat/stargazers"><img src="https://img.shields.io/github/stars/aszecsei/hexchat?colorA=363a4f&colorB=b7bdf8&style=for-the-badge"></a>
-	<a href="https://github.com/aszecsei/hexchat/issues"><img src="https://img.shields.io/github/issues/aszecsei/hexchat?colorA=363a4f&colorB=f5a97f&style=for-the-badge"></a>
-	<a href="https://github.com/aszecsei/hexchat/contributors"><img src="https://img.shields.io/github/contributors/aszecsei/hexchat?colorA=363a4f&colorB=a6da95&style=for-the-badge"></a>
+	<a href="https://github.com/catppuccin/hexchat/stargazers"><img src="https://img.shields.io/github/stars/catppuccin/hexchat?colorA=363a4f&colorB=b7bdf8&style=for-the-badge"></a>
+	<a href="https://github.com/catppuccin/hexchat/issues"><img src="https://img.shields.io/github/issues/catppuccin/hexchat?colorA=363a4f&colorB=f5a97f&style=for-the-badge"></a>
+	<a href="https://github.com/catppuccin/hexchat/contributors"><img src="https://img.shields.io/github/contributors/catppuccin/hexchat?colorA=363a4f&colorB=a6da95&style=for-the-badge"></a>
 </p>
 
 <p align="center">
@@ -36,23 +36,16 @@
 
 ## Usage
 
-1. Clone this repository locally
-2. Run the installation script while HexChat is closed:
-```sh
-./install 'latte' # or frappe, macchiato, mocha 
-```
-3. Launch HexChat
-
-Alternatively, for manual installation:
-
-2. Copy the desired `colors.conf` file to `$XDG_CONFIG_HOME/hexchat/` (usually this is `~/.config/hexchat`)
-	- For example: `cp frappe/colors.conf ~/.config/hexchat/colors.conf`
+1. Make sure HexChat is closed.
+2. Copy the `colors.conf` of the flavor of your choice to your [HexChat configuration directory](https://hexchat.readthedocs.io/en/latest/settings.html#config-files).
+3. Launch HexChat.
 
 ## 🙋 FAQ
--   Q: **_"Why doesn't all of HexChat match the theme?"_**\
-	A: HexChat themes only affect the panel backgrounds and text colors; to get the rest of the window to match you'll also need the [GTK](https://github.com/catppuccin/gtk) theme.
--	Q: **_"Why isn't this working with flatpak?"_**\
-	A: Try copying the `colors.conf` file to `~/.var/app/io.github.Hexchat/config/hexchat/` instead.
+
+- Q: **_"Why doesn't all of HexChat match the theme?"_**\
+  A: HexChat themes only affect the panel backgrounds and text colors; to get the rest of the window to match you'll also need the [GTK](https://github.com/catppuccin/gtk) theme.
+- Q: **_"Why isn't this working with flatpak?"_**\
+  A: Try copying the `colors.conf` file to `~/.var/app/io.github.Hexchat/config/hexchat/` instead.
 
 ## 💝 Thanks to
 

--- a/install
+++ b/install
@@ -1,2 +1,0 @@
-#!/usr/bin/bash
-cp ${1}/colors.conf ${XDG_CONFIG_HOME:-$HOME/.config}/hexchat/colors.conf


### PR DESCRIPTION
Simplifies the usage instructions by removing the install script and linking to the documentation for the location of the configuration directories.